### PR TITLE
Test manual discount deletion in combination with vouchers

### DIFF
--- a/saleor/graphql/order/tests/mutations/test_order_discount.py
+++ b/saleor/graphql/order/tests/mutations/test_order_discount.py
@@ -9,6 +9,7 @@ from prices import Money, TaxedMoney, fixed_discount, percentage_discount
 from .....core.prices import quantize_price
 from .....discount import DiscountType, DiscountValueType
 from .....order import OrderEvents, OrderStatus
+from .....order.calculations import fetch_order_prices_if_expired
 from .....order.error_codes import OrderErrorCode
 from .....order.interface import OrderTaxedPricesData
 from ....discount.enums import DiscountValueTypeEnum
@@ -711,6 +712,14 @@ mutation OrderDiscountDelete($discountId: ID!){
       discounts {
         id
       }
+      total {
+        net {
+            amount
+        }
+        gross {
+            amount
+        }
+      }
     }
     errors{
       field
@@ -953,6 +962,55 @@ def test_delete_manual_discount_from_order_with_gift_promotion(
     assert gift_discount.value_type == DiscountValueType.FIXED
 
     assert order.total_net_amount == order.undiscounted_total_net_amount
+
+
+def test_delete_manual_discount_from_order_with_entire_order_voucher(
+    draft_order_with_fixed_discount_order,
+    staff_api_client,
+    permission_group_manage_orders,
+    voucher,
+    plugins_manager,
+):
+    # given
+    order = draft_order_with_fixed_discount_order
+    currency = order.currency
+    manual_discount = draft_order_with_fixed_discount_order.discounts.get()
+    code = voucher.codes.first().code
+    order.voucher_code = code
+    order.voucher = voucher
+    order.save(update_fields=["voucher_code", "voucher"])
+    fetch_order_prices_if_expired(order, plugins_manager, None, True)
+    assert order.discounts.get() == manual_discount
+    voucher_discount_amount = voucher.channel_listings.get().discount
+    undiscounted_total_net_amount = order.undiscounted_total_net_amount
+    total_net_amount = undiscounted_total_net_amount - voucher_discount_amount.amount
+
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    variables = {
+        "discountId": graphene.Node.to_global_id("OrderDiscount", manual_discount.pk),
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_DISCOUNT_DELETE, variables)
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["orderDiscountDelete"]
+    assert not data["errors"]
+
+    with pytest.raises(manual_discount._meta.model.DoesNotExist):
+        manual_discount.refresh_from_db()
+
+    voucher_discount = order.discounts.get()
+    assert voucher_discount.type == DiscountType.VOUCHER
+    assert voucher_discount.amount.amount == voucher_discount_amount.amount
+    assert voucher_discount.reason == f"Voucher code: {code}"
+
+    assert order.undiscounted_total_net_amount == undiscounted_total_net_amount
+    assert (
+        quantize_price(Decimal(data["order"]["total"]["net"]["amount"]), currency)
+        == total_net_amount
+    )
 
 
 ORDER_LINE_DISCOUNT_UPDATE = """
@@ -1377,6 +1435,14 @@ mutation OrderLineDiscountRemove($orderLineId: ID!){
   orderLineDiscountRemove(orderLineId: $orderLineId){
     orderLine{
       id
+      totalPrice {
+        net {
+            amount
+        }
+        gross {
+            amount
+        }
+      }
     }
     errors{
       field
@@ -1624,14 +1690,13 @@ def test_delete_order_line_discount_order_is_not_draft(
 
 
 def test_delete_order_line_discount_line_with_catalogue_promotion(
-    order_with_lines,
+    order_with_lines_and_catalogue_promotion,
     staff_api_client,
     permission_group_manage_orders,
-    catalogue_promotion,
 ):
     # given
     permission_group_manage_orders.user_set.add(staff_api_client.user)
-    order = order_with_lines
+    order = order_with_lines_and_catalogue_promotion
     order.status = OrderStatus.DRAFT
     order.save(update_fields=["status"])
     line = order.lines.get(quantity=3)
@@ -1657,6 +1722,122 @@ def test_delete_order_line_discount_line_with_catalogue_promotion(
     content = get_graphql_content(response)
     data = content["data"]["orderLineDiscountRemove"]
     assert not data["errors"]
-    # Deleting manual discount should result in creating catalogue discount in this case
-    # https://github.com/saleor/saleor/issues/15517
-    # assert line.discounts.filter(type=DiscountType.PROMOTION).exists()
+    assert line.discounts.filter(type=DiscountType.PROMOTION).exists()
+
+
+def test_delete_order_line_discount_with_line_level_voucher(
+    order_with_lines,
+    staff_api_client,
+    permission_group_manage_orders,
+    voucher_specific_product_type,
+    tax_configuration_flat_rates,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    voucher = voucher_specific_product_type
+    order = order_with_lines
+    currency = order.currency
+    line = order.lines.get(quantity=3)
+    voucher.products.add(line.variant.product)
+    order.status = OrderStatus.DRAFT
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+    order.save(update_fields=["status", "voucher", "voucher_code"])
+
+    assert voucher.discount_value_type == DiscountValueType.PERCENTAGE
+    line_undiscounted_total_price = line.undiscounted_total_price.net.amount
+    voucher_discount_value = voucher.channel_listings.get().discount_value
+    voucher_discount_amount = quantize_price(
+        line_undiscounted_total_price * voucher_discount_value / 100, currency
+    )
+
+    manual_reward_value = Decimal(1)
+    manual_line_discount = line.discounts.create(
+        type=DiscountType.MANUAL,
+        value_type=DiscountValueType.FIXED,
+        value=manual_reward_value,
+        amount_value=manual_reward_value * line.quantity,
+        currency=order.currency,
+        reason="Manual line discount",
+    )
+
+    variables = {
+        "orderLineId": graphene.Node.to_global_id("OrderLine", line.pk),
+    }
+
+    # when
+    response = staff_api_client.post_graphql(ORDER_LINE_DISCOUNT_REMOVE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderLineDiscountRemove"]
+    assert not data["errors"]
+
+    with pytest.raises(manual_line_discount._meta.model.DoesNotExist):
+        manual_line_discount.refresh_from_db()
+
+    voucher_discount = line.discounts.get()
+    assert voucher_discount.type == DiscountType.VOUCHER
+    assert voucher_discount.amount.amount == voucher_discount_amount
+    assert voucher_discount.reason == f"Voucher code: {code}"
+
+    order_line = data["orderLine"]
+    assert (
+        order_line["totalPrice"]["net"]["amount"]
+        == line_undiscounted_total_price - voucher_discount_amount
+    )
+
+
+def test_delete_order_line_discount_with_line_level_voucher_deleted_in_meantime(
+    order_with_lines,
+    staff_api_client,
+    permission_group_manage_orders,
+    voucher_specific_product_type,
+    tax_configuration_flat_rates,
+):
+    # given
+    permission_group_manage_orders.user_set.add(staff_api_client.user)
+    voucher = voucher_specific_product_type
+    order = order_with_lines
+    line = order.lines.get(quantity=3)
+    voucher.products.add(line.variant.product)
+    order.status = OrderStatus.DRAFT
+    order.voucher = voucher
+    code = voucher.codes.first().code
+    order.voucher_code = code
+    order.save(update_fields=["status", "voucher", "voucher_code"])
+
+    assert voucher.discount_value_type == DiscountValueType.PERCENTAGE
+    line_undiscounted_total_price = line.undiscounted_total_price.net.amount
+
+    manual_reward_value = Decimal(1)
+    manual_line_discount = line.discounts.create(
+        type=DiscountType.MANUAL,
+        value_type=DiscountValueType.FIXED,
+        value=manual_reward_value,
+        amount_value=manual_reward_value * line.quantity,
+        currency=order.currency,
+        reason="Manual line discount",
+    )
+
+    variables = {
+        "orderLineId": graphene.Node.to_global_id("OrderLine", line.pk),
+    }
+
+    # when
+    voucher.delete()
+    response = staff_api_client.post_graphql(ORDER_LINE_DISCOUNT_REMOVE, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderLineDiscountRemove"]
+    assert not data["errors"]
+
+    with pytest.raises(manual_line_discount._meta.model.DoesNotExist):
+        manual_line_discount.refresh_from_db()
+
+    assert not line.discounts.first()
+
+    order_line = data["orderLine"]
+    assert order_line["totalPrice"]["net"]["amount"] == line_undiscounted_total_price

--- a/saleor/tests/e2e/orders/discounts/test_manual_order_discount_and_voucher.py
+++ b/saleor/tests/e2e/orders/discounts/test_manual_order_discount_and_voucher.py
@@ -1,0 +1,307 @@
+from decimal import Decimal
+
+import pytest
+
+from .....core.prices import quantize_price
+from .....discount import DiscountType, DiscountValueType
+from ... import DEFAULT_ADDRESS
+from ...product.utils.preparing_product import prepare_product
+from ...shop.utils.preparing_shop import prepare_shop
+from ...taxes.utils import update_country_tax_rates
+from ...utils import assign_permissions
+from ...vouchers.utils import create_voucher, create_voucher_channel_listing
+from ..utils import draft_order_create, draft_order_update, order_discount_add
+from ..utils.order_discount_delete import order_discount_delete
+
+
+def prepare_voucher(
+    e2e_staff_api_client,
+    channel_id,
+    voucher_code,
+    voucher_discount_type,
+    voucher_discount_value,
+    voucher_type,
+    usage_limit,
+    single_use,
+    apply_once_per_order,
+):
+    input = {
+        "code": voucher_code,
+        "discountValueType": voucher_discount_type,
+        "type": voucher_type,
+        "usageLimit": usage_limit,
+        "singleUse": single_use,
+        "applyOncePerOrder": apply_once_per_order,
+    }
+    voucher_data = create_voucher(e2e_staff_api_client, input)
+
+    voucher_id = voucher_data["id"]
+    channel_listing = [
+        {
+            "channelId": channel_id,
+            "discountValue": voucher_discount_value,
+        },
+    ]
+    create_voucher_channel_listing(
+        e2e_staff_api_client,
+        voucher_id,
+        channel_listing,
+    )
+
+    return voucher_code, voucher_id, voucher_discount_value
+
+
+@pytest.mark.e2e
+def test_manual_order_discount_with_entire_order_voucher_CORE_0940(
+    e2e_staff_api_client,
+    shop_permissions,
+    permission_manage_product_types_and_attributes,
+    permission_manage_discounts,
+    permission_manage_orders,
+):
+    # Before
+    permissions = [
+        *shop_permissions,
+        permission_manage_product_types_and_attributes,
+        permission_manage_discounts,
+        permission_manage_orders,
+    ]
+    assign_permissions(e2e_staff_api_client, permissions)
+
+    tax_settings = {
+        "charge_taxes": True,
+        "tax_calculation_strategy": "FLAT_RATES",
+        "prices_entered_with_tax": False,
+    }
+    shipping_base_price = Decimal(10)
+    currency = "USD"
+    shop_data, _tax_config = prepare_shop(
+        e2e_staff_api_client,
+        channels=[
+            {
+                "shipping_zones": [
+                    {
+                        "countries": ["US"],
+                        "shipping_methods": [
+                            {
+                                "name": "Inpost",
+                                "add_channels": {"price": shipping_base_price},
+                            }
+                        ],
+                    },
+                ],
+                "order_settings": {
+                    "includeDraftOrderInVoucherUsage": True,
+                },
+            }
+        ],
+        tax_settings=tax_settings,
+    )
+    channel_id = shop_data[0]["id"]
+    warehouse_id = shop_data[0]["warehouse_id"]
+    shipping_method_id = shop_data[0]["shipping_zones"][0]["shipping_methods"][0]["id"]
+
+    tax_rate = Decimal("1.1")
+    update_country_tax_rates(
+        e2e_staff_api_client,
+        "US",
+        [{"rate": (tax_rate - 1) * 100}],
+    )
+
+    variant_price = Decimal(20)
+    (
+        product_id,
+        product_variant_id,
+        product_variant_price,
+    ) = prepare_product(
+        e2e_staff_api_client, warehouse_id, channel_id, variant_price=variant_price
+    )
+
+    # Step 1 - Create draft order
+    quantity = 2
+    input = {
+        "channelId": channel_id,
+        "billingAddress": DEFAULT_ADDRESS,
+        "shippingAddress": DEFAULT_ADDRESS,
+        "shippingMethod": shipping_method_id,
+        "userEmail": "test_user@test.com",
+        "lines": [{"variantId": product_variant_id, "quantity": quantity}],
+    }
+    data = draft_order_create(e2e_staff_api_client, input)
+    undiscounted_line_total = quantize_price(variant_price * quantity, currency)
+    undiscounted_total = undiscounted_line_total + shipping_base_price
+
+    order_data = data["order"]
+    order_id = order_data["id"]
+    assert not order_data["discounts"]
+    assert order_data["shippingPrice"]["net"]["amount"] == shipping_base_price
+    assert order_data["shippingPrice"]["gross"]["amount"] == quantize_price(
+        shipping_base_price * tax_rate, currency
+    )
+    assert order_data["total"]["net"]["amount"] == undiscounted_total
+    assert order_data["total"]["gross"]["amount"] == quantize_price(
+        undiscounted_total * tax_rate, currency
+    )
+    assert len(order_data["lines"]) == 1
+    line_data = order_data["lines"][0]
+    assert line_data["unitPrice"]["net"]["amount"] == variant_price
+    assert line_data["unitPrice"]["gross"]["amount"] == quantize_price(
+        variant_price * tax_rate, currency
+    )
+    assert line_data["totalPrice"]["net"]["amount"] == undiscounted_line_total
+    assert line_data["totalPrice"]["gross"]["amount"] == quantize_price(
+        undiscounted_line_total * tax_rate, currency
+    )
+
+    # Step 2 - Add entire order voucher
+    voucher_discount_amount = Decimal(10)
+    voucher_code, voucher_id, voucher_discount_value = prepare_voucher(
+        e2e_staff_api_client,
+        channel_id,
+        voucher_code="code-123",
+        voucher_discount_type="FIXED",
+        voucher_discount_value=voucher_discount_amount,
+        voucher_type="ENTIRE_ORDER",
+        usage_limit=10,
+        single_use=False,
+        apply_once_per_order=False,
+    )
+    data = draft_order_update(
+        e2e_staff_api_client, order_id, {"voucherCode": voucher_code}
+    )
+    order_data = data["order"]
+    assert len(order_data["discounts"]) == 1
+    voucher_discount_data = order_data["discounts"][0]
+    assert voucher_discount_data["type"] == DiscountType.VOUCHER.upper()
+    assert voucher_discount_data["value"] == voucher_discount_value
+    assert voucher_discount_data["valueType"] == DiscountValueType.FIXED.upper()
+    assert voucher_discount_data["reason"] == f"Voucher code: {voucher_code}"
+    assert voucher_discount_data["amount"]["amount"] == voucher_discount_amount
+
+    expected_total = undiscounted_total - voucher_discount_amount
+    expected_line_total = undiscounted_line_total - voucher_discount_amount
+    expected_unit_price = quantize_price(expected_line_total / quantity, currency)
+
+    assert order_data["shippingPrice"]["net"]["amount"] == shipping_base_price
+    assert order_data["shippingPrice"]["gross"]["amount"] == quantize_price(
+        shipping_base_price * tax_rate, currency
+    )
+    assert order_data["total"]["net"]["amount"] == expected_total
+    assert order_data["total"]["gross"]["amount"] == quantize_price(
+        expected_total * tax_rate, currency
+    )
+    assert len(order_data["lines"]) == 1
+    line_data = order_data["lines"][0]
+    assert line_data["unitPrice"]["net"]["amount"] == expected_unit_price
+    assert line_data["unitPrice"]["gross"]["amount"] == quantize_price(
+        expected_unit_price * tax_rate, currency
+    )
+    assert line_data["totalPrice"]["net"]["amount"] == expected_line_total
+    assert line_data["totalPrice"]["gross"]["amount"] == quantize_price(
+        expected_line_total * tax_rate, currency
+    )
+
+    assert order_data["voucher"]["codes"]["totalCount"] == 1
+    assert order_data["voucher"]["codes"]["edges"][0]["node"]["code"] == voucher_code
+    assert order_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 1
+
+    # Step 3 - dd manual order discountA
+    # Manual discount should override voucher
+    manual_discount_amount = Decimal(20)
+    manual_discount_reason = "Staff discount"
+    data = order_discount_add(
+        e2e_staff_api_client,
+        order_id,
+        {
+            "valueType": DiscountValueType.FIXED.upper(),
+            "value": manual_discount_amount,
+            "reason": manual_discount_reason,
+        },
+    )
+
+    order_data = data["order"]
+    assert len(order_data["discounts"]) == 1
+    manual_discount_data = order_data["discounts"][0]
+    manual_discount_id = manual_discount_data["id"]
+    assert manual_discount_data["type"] == DiscountType.MANUAL.upper()
+    assert manual_discount_data["value"] == manual_discount_amount
+    assert manual_discount_data["valueType"] == DiscountValueType.FIXED.upper()
+    assert manual_discount_data["reason"] == manual_discount_reason
+    assert manual_discount_data["amount"]["amount"] == manual_discount_amount
+
+    subtotal_discount_portion = quantize_price(
+        undiscounted_line_total / undiscounted_total * manual_discount_amount, currency
+    )
+    shipping_discount_portion = manual_discount_amount - subtotal_discount_portion
+
+    expected_total = undiscounted_total - manual_discount_amount
+    expected_shipping_price = shipping_base_price - shipping_discount_portion
+    expected_line_total = undiscounted_line_total - subtotal_discount_portion
+    expected_unit_price = quantize_price(expected_line_total / quantity, currency)
+
+    assert order_data["shippingPrice"]["net"]["amount"] == expected_shipping_price
+    assert quantize_price(
+        Decimal(order_data["shippingPrice"]["gross"]["amount"]), currency
+    ) == quantize_price(expected_shipping_price * tax_rate, currency)
+    assert order_data["total"]["net"]["amount"] == expected_total
+    assert order_data["total"]["gross"]["amount"] == quantize_price(
+        expected_total * tax_rate, currency
+    )
+    assert len(order_data["lines"]) == 1
+    line_data = order_data["lines"][0]
+    assert line_data["unitPrice"]["net"]["amount"] == expected_unit_price
+    assert quantize_price(
+        Decimal(line_data["unitPrice"]["gross"]["amount"]), currency
+    ) == quantize_price(expected_unit_price * tax_rate, currency)
+    assert line_data["totalPrice"]["net"]["amount"] == expected_line_total
+    assert quantize_price(
+        Decimal(line_data["totalPrice"]["gross"]["amount"]), currency
+    ) == quantize_price(expected_line_total * tax_rate, currency)
+
+    # Manual discount overrides voucher's discount, but don't disconnect it
+    # from the order. The code usage shouldn't be reduced
+    assert order_data["voucherCode"] == voucher_code
+    assert order_data["voucher"]["codes"]["totalCount"] == 1
+    assert order_data["voucher"]["codes"]["edges"][0]["node"]["code"] == voucher_code
+    assert order_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 1
+
+    # Step 4 - Delete manual order discount
+    # Voucher should be applied back
+    data = order_discount_delete(e2e_staff_api_client, manual_discount_id)
+
+    order_data = data["order"]
+    assert len(order_data["discounts"]) == 1
+    voucher_discount_data = order_data["discounts"][0]
+    assert voucher_discount_data["type"] == DiscountType.VOUCHER.upper()
+    assert voucher_discount_data["value"] == voucher_discount_value
+    assert voucher_discount_data["valueType"] == DiscountValueType.FIXED.upper()
+    assert voucher_discount_data["reason"] == f"Voucher code: {voucher_code}"
+    assert voucher_discount_data["amount"]["amount"] == voucher_discount_amount
+
+    expected_total = undiscounted_total - voucher_discount_amount
+    expected_line_total = undiscounted_line_total - voucher_discount_amount
+    expected_unit_price = quantize_price(expected_line_total / quantity, currency)
+
+    assert order_data["shippingPrice"]["net"]["amount"] == shipping_base_price
+    assert order_data["shippingPrice"]["gross"]["amount"] == quantize_price(
+        shipping_base_price * tax_rate, currency
+    )
+    assert order_data["total"]["net"]["amount"] == expected_total
+    assert order_data["total"]["gross"]["amount"] == quantize_price(
+        expected_total * tax_rate, currency
+    )
+    assert len(order_data["lines"]) == 1
+    line_data = order_data["lines"][0]
+    assert line_data["unitPrice"]["net"]["amount"] == expected_unit_price
+    assert line_data["unitPrice"]["gross"]["amount"] == quantize_price(
+        expected_unit_price * tax_rate, currency
+    )
+    assert line_data["totalPrice"]["net"]["amount"] == expected_line_total
+    assert line_data["totalPrice"]["gross"]["amount"] == quantize_price(
+        expected_line_total * tax_rate, currency
+    )
+
+    assert order_data["voucherCode"] == voucher_code
+    assert order_data["voucher"]["codes"]["totalCount"] == 1
+    assert order_data["voucher"]["codes"]["edges"][0]["node"]["code"] == voucher_code
+    assert order_data["voucher"]["codes"]["edges"][0]["node"]["used"] == 1

--- a/saleor/tests/e2e/orders/utils/draft_order_create.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_create.py
@@ -36,28 +36,48 @@ mutation OrderDraftCreate($input: DraftOrderCreateInput!) {
       shippingMethods {
         id
       }
+      undiscountedTotal {
+        ... BaseTaxedMoney
+      }
+      total {
+        ... BaseTaxedMoney
+      }
+      shippingPrice {
+        ... BaseTaxedMoney
+      }
       lines {
         productVariantId
         quantity
         undiscountedUnitPrice {
-          gross {
-            amount
-          }
+          ... BaseTaxedMoney
         }
         unitPrice {
-          gross {
-            amount
-          }
+          ... BaseTaxedMoney
+        }
+        undiscountedTotalPrice {
+          ... BaseTaxedMoney
         }
         totalPrice {
-          gross {
-            amount
-          }
+          ... BaseTaxedMoney
         }
       }
     }
   }
 }
+
+fragment BaseTaxedMoney on TaxedMoney {
+  gross {
+    amount
+  }
+  net {
+    amount
+  }
+  tax {
+    amount
+  }
+  currency
+}
+
 """
 
 

--- a/saleor/tests/e2e/orders/utils/draft_order_update.py
+++ b/saleor/tests/e2e/orders/utils/draft_order_update.py
@@ -37,6 +37,17 @@ mutation DraftOrderUpdate($input: DraftOrderInput!, $id: ID!) {
         id
         code
         discountValue
+        codes(first: 10) {
+            edges {
+              node {
+                id
+                code
+                isActive
+                used
+              }
+            }
+            totalCount
+          }
       }
       discounts {
         id

--- a/saleor/tests/e2e/orders/utils/order_discount_delete.py
+++ b/saleor/tests/e2e/orders/utils/order_discount_delete.py
@@ -1,8 +1,8 @@
 from saleor.graphql.tests.utils import get_graphql_content
 
-ORDER_DISCOUNT_ADD_MUTATION = """
-mutation OrderDiscountAdd($input: OrderDiscountCommonInput!, $id: ID!) {
-  orderDiscountAdd(input: $input, orderId: $id) {
+ORDER_DISCOUNT_DELETE_MUTATION = """
+mutation OrderDiscountDelete($discountId: ID!){
+  orderDiscountDelete(discountId: $discountId){
     errors {
       message
       field
@@ -51,8 +51,6 @@ mutation OrderDiscountAdd($input: OrderDiscountCommonInput!, $id: ID!) {
       voucherCode
       voucher {
         id
-        code
-        discountValue
         codes(first: 10) {
             edges {
               node {
@@ -84,23 +82,13 @@ fragment BaseTaxedMoney on TaxedMoney {
 """
 
 
-def order_discount_add(
-    api_client,
-    id,
-    input,
-):
-    variables = {"id": id, "input": input}
-
+def order_discount_delete(api_client, id):
     response = api_client.post_graphql(
-        ORDER_DISCOUNT_ADD_MUTATION,
-        variables=variables,
+        ORDER_DISCOUNT_DELETE_MUTATION,
+        variables={"discountId": id},
     )
     content = get_graphql_content(response)
-    data = content["data"]["orderDiscountAdd"]
-    order_id = data["order"]["id"]
-    errors = data["errors"]
-
-    assert errors == []
-    assert order_id is not None
+    data = content["data"]["orderDiscountDelete"]
+    assert not data["errors"]
 
     return data


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17057

This PR adds missing tests for cases when user deletes manual discounts from an order with voucher associated.

Internal issue: https://linear.app/saleor/issue/SHOPX-1585
Docs PR: https://github.com/saleor/saleor-docs/pull/1399

<!-- Please mention all relevant issue numbers. -->

# Impact

- [ ] New migrations
- [ ] New/Updated API fields or mutations
- [ ] Deprecated API fields or mutations
- [ ] Removed API types, fields, or mutations

# Docs

<!-- Docs are stored in a separat...